### PR TITLE
We shouldn't try and collect data from the future

### DIFF
--- a/apps/habits/models.py
+++ b/apps/habits/models.py
@@ -297,7 +297,7 @@ class Habit(models.Model):
             min_index = buckets[0].index + 1
 
         ret = []
-        for idx in reversed(range(min_index, time_period.index + 1)):
+        for idx in reversed(range(min_index, time_period.index)):
             ret.append(TimePeriod.from_index(self.start, self.resolution, idx))
 
         return ret

--- a/apps/habits/tests/test_models.py
+++ b/apps/habits/tests/test_models.py
@@ -208,6 +208,17 @@ RECENT_TIME_PERIODS_FIXTURES = (
     # [TimePeriod(resolution='week', index=0, date=datetime.date(2013, 4, 29))]
     # i.e. it expects data for the w/c 29th April. I say that's wrong.
     RTPT('2013-05-01', 'week', (), '2013-05-02', [0]),
+    # Habit started 1st May, weekly, data has been entered for 2nd week
+    # Today is 29th May.
+    # Therefore we expect data for the 3rd and 4th week
+    # I think it should be only the 3rd week
+    RTPT('2013-05-01', 'week', (('2013-05-13',1),), '2013-05-29', [4,3]),
+    # Habit started 1st May, weekly.
+    # Data has been entered for 1st week, 2nd week and 4th week
+    # Today is 18th June.
+    # Therefore we expect data for the 5th, 6th and 7th week
+    # I think it should be only the 5th and 6th
+    RTPT('2013-05-01', 'week', (('2013-05-06',1),('2013-05-13',1),('2013-05-27',1)), '2013-06-18', [7,6,5]),
 )
 
 TPFNF = namedtuple('TimePeriodFriendlyNameFixture', 'start resolution relative expected')

--- a/apps/habits/tests/test_models.py
+++ b/apps/habits/tests/test_models.py
@@ -200,6 +200,14 @@ RECENT_TIME_PERIODS_FIXTURES = (
     # Today is 5th March.
     # Therefore, we consider ourselves to be up-to-date with data.
     RTPT('2013-03-01', 'day', (('2013-03-05',1),), '2013-03-05', []),
+    # Habit started 1st May, weekly, no data has been entered.
+    # Today is 2nd May.
+    # Therefore we expect data for the 0th week.
+    # This is the logic I think is incorrect.
+    # The TimePeriod returned is this:
+    # [TimePeriod(resolution='week', index=0, date=datetime.date(2013, 4, 29))]
+    # i.e. it expects data for the w/c 29th April. I say that's wrong.
+    RTPT('2013-05-01', 'week', (), '2013-05-02', [0]),
 )
 
 TPFNF = namedtuple('TimePeriodFriendlyNameFixture', 'start resolution relative expected')

--- a/apps/habits/tests/test_models.py
+++ b/apps/habits/tests/test_models.py
@@ -185,8 +185,20 @@ STREAKS_FIXTURES = (
 RTPT = namedtuple('RecentTimePeriodTest', 'start resolution data date expected')
 
 RECENT_TIME_PERIODS_FIXTURES = (
+    # Habit started 1st March, daily, no data has been entered.
+    # Today is 5th March.
+    # Therefore, we expect data from the five days between (and including) 1st
+    # and 5th March.
     RTPT('2013-03-01', 'day', (), '2013-03-05', [4,3,2,1,0]),
+    # Habit started 1st March, daily, data has been entered for March 3rd.
+    # Today is 5th March.
+    # Therefore we expect data for the 4th, and the 5th of March (i.e. the 3rd
+    # and 4th time period).
+    # We have written off the 0th and 1st time period (1st, 2nd March).
     RTPT('2013-03-01', 'day', (('2013-03-03',1),), '2013-03-05', [4,3]),
+    # Habit started 1st March, daily, data has been entered for 5th March.
+    # Today is 5th March.
+    # Therefore, we consider ourselves to be up-to-date with data.
     RTPT('2013-03-01', 'day', (('2013-03-05',1),), '2013-03-05', []),
 )
 

--- a/apps/habits/tests/test_models.py
+++ b/apps/habits/tests/test_models.py
@@ -189,13 +189,13 @@ RECENT_TIME_PERIODS_FIXTURES = (
     # Today is 5th March.
     # Therefore, we expect data from the five days between (and including) 1st
     # and 5th March.
-    RTPT('2013-03-01', 'day', (), '2013-03-05', [4,3,2,1,0]),
+    RTPT('2013-03-01', 'day', (), '2013-03-05', [3,2,1,0]),
     # Habit started 1st March, daily, data has been entered for March 3rd.
     # Today is 5th March.
     # Therefore we expect data for the 4th, and the 5th of March (i.e. the 3rd
     # and 4th time period).
     # We have written off the 0th and 1st time period (1st, 2nd March).
-    RTPT('2013-03-01', 'day', (('2013-03-03',1),), '2013-03-05', [4,3]),
+    RTPT('2013-03-01', 'day', (('2013-03-03',1),), '2013-03-05', [3]),
     # Habit started 1st March, daily, data has been entered for 5th March.
     # Today is 5th March.
     # Therefore, we consider ourselves to be up-to-date with data.
@@ -207,18 +207,18 @@ RECENT_TIME_PERIODS_FIXTURES = (
     # The TimePeriod returned is this:
     # [TimePeriod(resolution='week', index=0, date=datetime.date(2013, 4, 29))]
     # i.e. it expects data for the w/c 29th April. I say that's wrong.
-    RTPT('2013-05-01', 'week', (), '2013-05-02', [0]),
+    RTPT('2013-05-01', 'week', (), '2013-05-02', []),
     # Habit started 1st May, weekly, data has been entered for 2nd week
     # Today is 29th May.
     # Therefore we expect data for the 3rd and 4th week
     # I think it should be only the 3rd week
-    RTPT('2013-05-01', 'week', (('2013-05-13',1),), '2013-05-29', [4,3]),
+    RTPT('2013-05-01', 'week', (('2013-05-13',1),), '2013-05-29', [3]),
     # Habit started 1st May, weekly.
     # Data has been entered for 1st week, 2nd week and 4th week
     # Today is 18th June.
     # Therefore we expect data for the 5th, 6th and 7th week
     # I think it should be only the 5th and 6th
-    RTPT('2013-05-01', 'week', (('2013-05-06',1),('2013-05-13',1),('2013-05-27',1)), '2013-06-18', [7,6,5]),
+    RTPT('2013-05-01', 'week', (('2013-05-06',1),('2013-05-13',1),('2013-05-27',1)), '2013-06-18', [6,5]),
 )
 
 TPFNF = namedtuple('TimePeriodFriendlyNameFixture', 'start resolution relative expected')

--- a/apps/habits/tests/test_models.py
+++ b/apps/habits/tests/test_models.py
@@ -187,13 +187,11 @@ RTPT = namedtuple('RecentTimePeriodTest', 'start resolution data date expected')
 RECENT_TIME_PERIODS_FIXTURES = (
     # Habit started 1st March, daily, no data has been entered.
     # Today is 5th March.
-    # Therefore, we expect data from the five days between (and including) 1st
-    # and 5th March.
+    # Therefore, we expect data from the four days from 1st to 4th March
     RTPT('2013-03-01', 'day', (), '2013-03-05', [3,2,1,0]),
     # Habit started 1st March, daily, data has been entered for March 3rd.
     # Today is 5th March.
-    # Therefore we expect data for the 4th, and the 5th of March (i.e. the 3rd
-    # and 4th time period).
+    # Therefore we expect data for the 4th of March
     # We have written off the 0th and 1st time period (1st, 2nd March).
     RTPT('2013-03-01', 'day', (('2013-03-03',1),), '2013-03-05', [3]),
     # Habit started 1st March, daily, data has been entered for 5th March.
@@ -202,22 +200,16 @@ RECENT_TIME_PERIODS_FIXTURES = (
     RTPT('2013-03-01', 'day', (('2013-03-05',1),), '2013-03-05', []),
     # Habit started 1st May, weekly, no data has been entered.
     # Today is 2nd May.
-    # Therefore we expect data for the 0th week.
-    # This is the logic I think is incorrect.
-    # The TimePeriod returned is this:
-    # [TimePeriod(resolution='week', index=0, date=datetime.date(2013, 4, 29))]
-    # i.e. it expects data for the w/c 29th April. I say that's wrong.
+    # Therefore we consider ourselves to be up-to-date with data
     RTPT('2013-05-01', 'week', (), '2013-05-02', []),
     # Habit started 1st May, weekly, data has been entered for 2nd week
-    # Today is 29th May.
-    # Therefore we expect data for the 3rd and 4th week
-    # I think it should be only the 3rd week
+    # Today is 29th May (4th week).
+    # Therefore we expect data for the 3rd week
     RTPT('2013-05-01', 'week', (('2013-05-13',1),), '2013-05-29', [3]),
     # Habit started 1st May, weekly.
     # Data has been entered for 1st week, 2nd week and 4th week
-    # Today is 18th June.
-    # Therefore we expect data for the 5th, 6th and 7th week
-    # I think it should be only the 5th and 6th
+    # Today is 18th June (7th week).
+    # Therefore we expect data for the 5th and 6th week
     RTPT('2013-05-01', 'week', (('2013-05-06',1),('2013-05-13',1),('2013-05-27',1)), '2013-06-18', [6,5]),
 )
 

--- a/apps/habits/tests/test_reminders.py
+++ b/apps/habits/tests/test_reminders.py
@@ -24,7 +24,7 @@ DATA_COLLECTION_FIXTURES = (
     ('weekendday', '2013-03-11', True),
     ('weekendday', '2013-03-12', False),
     ('week', '2013-03-10', False),
-    ('week', '2013-03-11', True),
+    ('week', '2013-03-11', True), # only send week reminders on Mondays
     ('week', '2013-03-12', False),
     ('month', '2013-03-13', False),
     ('month', '2013-03-31', False),

--- a/apps/habits/tests/test_views.py
+++ b/apps/habits/tests/test_views.py
@@ -85,7 +85,7 @@ class HabitRecordViewTest(WebTest):
     def test_record_post_two(self):
         self.habit = Habit.objects.create(
             description="Frob my Hobbits",
-            start=datetime.date.today() - datetime.timedelta(days=1),
+            start=datetime.date.today() - datetime.timedelta(days=2),
             user=self.user,
             resolution='day',
             target_value=2,
@@ -106,7 +106,7 @@ class HabitRecordViewTest(WebTest):
     def test_record_post_two_not_at_start(self):
         self.habit = Habit.objects.create(
             description="Frob my Hobbits",
-            start=datetime.date.today() - datetime.timedelta(days=2),
+            start=datetime.date.today() - datetime.timedelta(days=3),
             user=self.user,
             resolution='day',
             target_value=2,
@@ -169,7 +169,7 @@ class HabitRecordViewTest(WebTest):
     def test_post_yes_no_habit(self):
         self.habit = Habit.objects.create(
             description="Frob my Hobbits",
-            start=datetime.date.today() - datetime.timedelta(days=2),
+            start=datetime.date.today() - datetime.timedelta(days=3),
             user=self.user,
             resolution='day',
             target_value=1,

--- a/apps/habits/tests/test_views.py
+++ b/apps/habits/tests/test_views.py
@@ -54,7 +54,7 @@ class HabitRecordViewTest(WebTest):
         )
         self.habit = Habit.objects.create(
             description="Brush my teeth",
-            start=datetime.date.today(),
+            start=datetime.date.today() - datetime.timedelta(days=1),
             user=self.user,
             resolution='day',
             target_value=2,

--- a/apps/habits/tests/test_views.py
+++ b/apps/habits/tests/test_views.py
@@ -133,7 +133,7 @@ class HabitRecordViewTest(WebTest):
     def test_record_post_ignore_existing_buckets(self):
         self.habit = Habit.objects.create(
             description="Frob my Hobbits",
-            start=datetime.date.today() - datetime.timedelta(days=1),
+            start=datetime.date.today() - datetime.timedelta(days=2),
             user=self.user,
             resolution='day',
             target_value=2,
@@ -141,9 +141,9 @@ class HabitRecordViewTest(WebTest):
         self.habit.record(self.habit.get_time_period(self.habit.start), 17)
         time_period = self.habit.get_current_time_period()
         params = {
-            '0-date': time_period.date,
+            '0-date': (time_period.date - datetime.timedelta(days=1)),
             '0-value': 2,
-            '1-date': time_period.date,
+            '1-date': (time_period.date - datetime.timedelta(days=1)),
             '1-value': 2,
         }
         response = self.app.post(reverse('habit_record', args=[self.habit.id]), params, user='someone@example.com')

--- a/apps/habits/views.py
+++ b/apps/habits/views.py
@@ -61,7 +61,7 @@ def habit_record_view(request, pk):
     _forms = []
 
     for period in time_periods:
-        # To make the lable for the input dynamic we need to create a new class
+        # To make the label for the input dynamic we need to create a new class
         # each time. This might be better done as a Widget instead...?
         class HabitForm(forms.Form):
             date = forms.DateField(required=True, widget=forms.HiddenInput)


### PR DESCRIPTION
This pull request addresses issue #40. I hadn't quite understood the problem when I raised the issue so to restate it here: 

Be Habitual requests information for the current time period. This is not a major problem if the time period is a day, but if it's a week it means you get an email at 9.30 on Monday morning asking you how you have done, and the link takes you to a page which wants the upcoming week's data (i.e. future data).

This is nonsensical, but it's also problematic in that you are not permitted to enter only _some_ data on that page. So if I want to enter last week's data only, I can't, I also need to enter data for this week, which hasn't happened yet. So I have to wait until the end of this week to enter last week's data, or set this week's data forever to 0. 
1. I think the longer term solution for this is actually slightly more complex logic on the record progress page, such that you cannot leave the page without entering previous time periods' data but data on the current week does not have to be entered/can be altered. That would also address #39 and #36.
2. In the current absence of that more complex logic, we can default to either:
   (a) having to enter the current period's data
   (b) not being able to enter the current period's data
   Currently, it is (a). This leads to the non-sensical situation I described above. Therefore, the changes in this PR changes the logic so it defaults instead to (b).
3. The logic change is here: dec0b825
   It looks like the +1 is solely to ensure we include the current time period.
4. I have also had to change tests other than the one I changed to reflect the exact behaviour I was changing. Therefore I'd really appreciate a close eye on this from others - especially in case there are other areas that use this functionality that are not unit tested.

Paricularly @nickstenning and @ashb who worked on this file; and/or @georgebrock, @mnowster, @SteveMarshall, @jaylett, @jcoglan, or @norm.

Oh, and the other thing I haven't done is tested it locally as my local running Be Habitual falls over when I try and create a habit (on master as well as this branch). Tips on that welcome...

If this is merged whoever does that could also raise an issue for point 1?

Cheers! To Industry!
